### PR TITLE
3.8.0

### DIFF
--- a/LaserBeamPatch.cs
+++ b/LaserBeamPatch.cs
@@ -8,7 +8,7 @@ namespace RGBLasers
     {
         protected override MethodBase GetTargetMethod()
         {
-            return typeof(LaserBeam).GetMethod("method_0", BindingFlags.NonPublic | BindingFlags.Instance);
+            return typeof(LaserBeam).GetMethod(nameof(LaserBeam.method_0));
         }
 
         [PatchPostfix]


### PR DESCRIPTION
Aki 3.8.0 changed the assembly quite a bit with their new deobfuscation method, they now brute-force most things to be public.
The mod failed to load because it was looking for `method_0` as a private member, but it's public now.
This PR fixes it.